### PR TITLE
BYTE-185: 24 Hr Countdown Zaius Promobar

### DIFF
--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -17,6 +17,8 @@
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
 
+
+                console.log(this.timerType);
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -12,22 +12,45 @@
         endsAtTime: '{{ $endsAtTime }}',
         startCounter: function () {
 
-        if( this.timerType === '24'){
-              let runningCounter = setInterval(() => {
+            if(this.timerType === '24'){
+                let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
-                let [hours, minutes, seconds] = this.endsAtTime.split(':');
-                let now = new Date();
-                let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
-                let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
                 let timeDistance = countDownDate - new Date().getTime();
+
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;
                 }
+
+                const [hours, minutes, seconds] = this.endsAtTime.split(':');
+                const now = new Date();
+                const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+
+                if(now > endTime){
+                    endTime.setDate(endTime.getDate() + 1);
+                }
+
+                const currentTime = new Date();
+                let tomorrowEndTimeDistance = endTime.getTime() - currentTime.getTime();
+
+                if(tomorrowEndTimeDistance <= 0){
+                    runningCounter = setInterval(resetCounter,1000);
+                }
+
                 this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
                 this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
                 this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
+
+                function resetCounter() {
+                    const now = new Date();
+                    const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+                    let tomorrowEndTimeDistance = endTime.getTime() - now.getTime();
+                    if (tomorrowEndTimeDistance <= 0) {
+                      clearInterval(runningCounter);
+                      runningCounter = setInterval(resetCounter, 1000);
+                    }
+                }
             }, 1000);
         }else{
             let runningCounter = setInterval(() => {

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -86,7 +86,6 @@
                 <span x-text="timer.minutes">{{ $minutes() }}</span> :
                 <span x-text="timer.seconds">{{ $seconds() }}</span>
             @else
-            here
                 {{ $slot }}
             @endif
         </span>

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -1,81 +1,77 @@
 @if($timerIsRunning())
     <span
-        x-data="
-    {
-        timer: {
-            days: '{{ $days() }}',
-            hours: '{{ $hours() }}',
-            minutes: '{{ $minutes() }}',
-            seconds: '{{ $seconds() }}',
-        },
-        timerType: '{{ $timerType }}',
-        endsAtTime: '{{ $endsAtTime }}',
-        startCounter: function () {
+        x-data="{
+            timer: {
+                days: '{{ $days() }}',
+                hours: '{{ $hours() }}',
+                minutes: '{{ $minutes() }}',
+                seconds: '{{ $seconds() }}',
+            },
+            timerType: '{{ $timerType }}',
+            endsAtTime: '{{ $endsAtTime }}',
+            startCounter: function () {
+                if (this.timerType === '24') {
+                    let runningCounter = setInterval(() => {
+                        let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
+                        let timeDistance = countDownDate - new Date().getTime();
 
-            if(this.timerType === '24'){
-                let runningCounter = setInterval(() => {
-                let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
-                let timeDistance = countDownDate - new Date().getTime();
+                        if (timeDistance < 0 ) {
+                            clearInterval(runningCounter);
+                            return;
+                        }
 
-                if (timeDistance < 0 ) {
-                    clearInterval(runningCounter);
-                    return;
+                        const [hours, minutes, seconds] = this.endsAtTime.split(':');
+                        const now = new Date();
+                        const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+
+                        if (now > endTime) {
+                            endTime.setDate(endTime.getDate() + 1);
+                        }
+
+                        const currentTime = new Date();
+                        let tomorrowEndTimeDistance = endTime.getTime() - currentTime.getTime();
+
+                        if (tomorrowEndTimeDistance <= 0) {
+                            runningCounter = setInterval(resetCounter,1000);
+                        }
+
+                        this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
+                        this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
+                        this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
+                        this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
+
+                        function resetCounter() {
+                            const now = new Date();
+                            const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+                            let tomorrowEndTimeDistance = endTime.getTime() - now.getTime();
+                            if (tomorrowEndTimeDistance <= 0) {
+                                clearInterval(runningCounter);
+                                runningCounter = setInterval(resetCounter, 1000);
+                            }
+                        }
+                    }, 1000);
+                } else {
+                    let runningCounter = setInterval(() => {
+                        let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
+                        let timeDistance = countDownDate - new Date().getTime();
+                        if (timeDistance < 0) {
+                            clearInterval(runningCounter);
+                            return;
+                        }
+                        this.timer.days = this.formatCounter(Math.floor(timeDistance / (1000 * 60 * 60 * 24)));
+                        this.timer.hours = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
+                        this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
+                        this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
+                    }, 1000);
                 }
-
-                const [hours, minutes, seconds] = this.endsAtTime.split(':');
-                const now = new Date();
-                const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
-
-                if(now > endTime){
-                    endTime.setDate(endTime.getDate() + 1);
-                }
-
-                const currentTime = new Date();
-                let tomorrowEndTimeDistance = endTime.getTime() - currentTime.getTime();
-
-                if(tomorrowEndTimeDistance <= 0){
-                    runningCounter = setInterval(resetCounter,1000);
-                }
-
-                this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
-                this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
-                this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
-                this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
-
-                function resetCounter() {
-                    const now = new Date();
-                    const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
-                    let tomorrowEndTimeDistance = endTime.getTime() - now.getTime();
-                    if (tomorrowEndTimeDistance <= 0) {
-                      clearInterval(runningCounter);
-                      runningCounter = setInterval(resetCounter, 1000);
-                    }
-                }
-            }, 1000);
-        }else{
-            let runningCounter = setInterval(() => {
-                let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
-                let timeDistance = countDownDate - new Date().getTime();
-                if (timeDistance < 0) {
-                    clearInterval(runningCounter);
-                    return;
-                }
-                this.timer.days = this.formatCounter(Math.floor(timeDistance / (1000 * 60 * 60 * 24)));
-                this.timer.hours = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
-                this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
-                this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
-            }, 1000);
-        }
-
-        },
-        formatCounter: function (number) {
-            return number.toString().padStart(2, '0');
-        },
-        timerIsRunning: function () {
-            return this.timer.days != 0 || this.timer.hours != 0 || this.timer.minutes != 0 || this.timer.seconds != 0;
-        }
-    }
-    "
+            },
+            formatCounter: function (number) {
+                return number.toString().padStart(2, '0');
+            },
+            timerIsRunning: function () {
+                return this.timer.days != 0 || this.timer.hours != 0 || this.timer.minutes != 0 || this.timer.seconds != 0;
+            }
+        }"
         x-init="startCounter()"
         {{ $attributes }}
     >

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -17,8 +17,6 @@
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
 
-
-                console.log(this.timerType);
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -8,7 +8,28 @@
             minutes: '{{ $minutes() }}',
             seconds: '{{ $seconds() }}',
         },
+        timerType: '{{ $timerType }}',
+        endsAtTime: '{{ $endsAtTime }}',
         startCounter: function () {
+
+        if( this.timerType === '24'){
+              let runningCounter = setInterval(() => {
+                let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
+                let [hours, minutes, seconds] = this.endsAtTime.split(':');
+                let now = new Date();
+                let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
+                let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
+                let timeDistance = countDownDate - new Date().getTime();
+                if (timeDistance < 0 ) {
+                    clearInterval(runningCounter);
+                    return;
+                }
+                this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
+                this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
+                this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
+                this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
+            }, 1000);
+        }else{
             let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
@@ -21,6 +42,8 @@
                 this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
             }, 1000);
+        }
+
         },
         formatCounter: function (number) {
             return number.toString().padStart(2, '0');
@@ -40,6 +63,7 @@
                 <span x-text="timer.minutes">{{ $minutes() }}</span> :
                 <span x-text="timer.seconds">{{ $seconds() }}</span>
             @else
+            here
                 {{ $slot }}
             @endif
         </span>

--- a/resources/views/promobar/settings.blade.php
+++ b/resources/views/promobar/settings.blade.php
@@ -100,10 +100,12 @@
         :toggled="$payload['countdown_timer_enabled'] ?? false"
     />
 
-
-     <x-fab::forms.select
+    <div
         x-cloak
         x-show="payload.countdown_timer_enabled === true"
+    >
+     <x-fab::forms.select
+
         wire:model="payload.countdown_timer_type"
         wire:key="promobar_countdown_timer_type"
         name="payload[countdown_timer_type]"
@@ -112,6 +114,7 @@
         <option value="24">24 Hours Countdown</option>
         <option value="regular">Regular Countdown</option>
     </x-fab::forms.select>
+    </div>
 
     <div
         class="grid grid-cols-2 w-full fab-space-x-4"

--- a/resources/views/promobar/settings.blade.php
+++ b/resources/views/promobar/settings.blade.php
@@ -102,17 +102,17 @@
 
     <div
         x-cloak
-        x-show="payload.countdown_timer_enabled === true"
+
     >
      <x-fab::forms.select
-
+        x-show="payload.countdown_timer_enabled === true"
         wire:model="payload.countdown_timer_type"
         wire:key="promobar_countdown_timer_type"
         name="payload[countdown_timer_type]"
         label="Countdown Timer Type"
     >
-        <option value="24">24 Hours Countdown</option>
         <option value="regular">Regular Countdown</option>
+        <option value="24">24 Hours Countdown</option>
     </x-fab::forms.select>
     </div>
 

--- a/resources/views/promobar/settings.blade.php
+++ b/resources/views/promobar/settings.blade.php
@@ -100,6 +100,19 @@
         :toggled="$payload['countdown_timer_enabled'] ?? false"
     />
 
+
+     <x-fab::forms.select
+        x-cloak
+        x-show="payload.countdown_timer_enabled === true"
+        wire:model="payload.countdown_timer_type"
+        wire:key="promobar_countdown_timer_type"
+        name="payload[countdown_timer_type]"
+        label="Countdown Timer Type"
+    >
+        <option value="24">24 Hours Countdown</option>
+        <option value="regular">Regular Countdown</option>
+    </x-fab::forms.select>
+
     <div
         class="grid grid-cols-2 w-full fab-space-x-4"
         x-cloak

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public string $timerType;
-    public string $endsAtTime;
+    public ?string $timerType;
+    public ?string $endsAtTime;
 
     public function __construct(protected array $payload)
     {

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -13,6 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
+    public $timerType;
+    public $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -21,6 +23,10 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
+
+        $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
+
+        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
     }
 
     public function days(): string

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public $timerType;
-    public $endsAtTime;
+    public string $timerType;
+    public string $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -23,10 +23,8 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
-
-        $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
-
-        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
+        $this->timerType = $this->payload['countdown_timer_type'] ?? "";
+        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : "";
     }
 
     public function days(): string


### PR DESCRIPTION
**Link to ticket**: https://linear.app/3zbrands/issue/BYTE-185/24-hr-countdown-zaius-promobar

<details>
<summary>Ticket description</summary>
User Story: 

As a Strata admin user, I want to be able to choose between a 24 hour timer that resets every 24 hours until a particular end date or a regular countdown timer that counts down to a day in the future and displays days, hours, minutes, and seconds remaining.


</details>

