### PR TITLE
BYTE-158: Styling Zaius Countdown Timer

### DIFF
--- a/resources/views/promobar/component.blade.php
+++ b/resources/views/promobar/component.blade.php
@@ -117,11 +117,9 @@
         <div class="flex md:hidden @if($payload['center_align_content'] ?? false) text-center @endif">{!! $payload['content_mobile'] ?? '' !!}</div>
         <div class="hidden md:flex">{!! $payload['content_desktop'] ?? '' !!}</div>
 
-
         @if($payload['countdown_timer_enabled'] ?? false)
             <x-promobar::countdown :payload="$payload" class="astrogoat_promobar_countdown" />
         @endif
-
 
         @if($payload['zaius_content_id'] ?? null)
             <button type="button" class="ml-4 no-wrap promobar-cta" onclick="openZaiusModal('{{ $payload['zaius_content_id'] ?? '' }}')">{!! $payload['button'] ?? '' !!}</button>

--- a/resources/views/promobar/component.blade.php
+++ b/resources/views/promobar/component.blade.php
@@ -41,6 +41,8 @@
 
     .astrogoat_promobar_countdown {
         margin-left: 10px;
+        display: flex;
+        justify-content: start;
     }
 
     .zaius-promobar .countdown-block{
@@ -54,6 +56,10 @@
 
     .zaius-promobar .timer-container{
         padding: 2px 0px;
+    }
+
+    .zaius-promobar .promobar-cta{
+        display: flex;
     }
 
     @media (min-width: 768px) {
@@ -86,6 +92,15 @@
     @media (min-width: 1280px) {
         .zaius-promobar .container {
             max-width: 1280px;
+        }
+
+        .zaius-promobar .timer-container{
+            padding: 2px 0px;
+            margin-top: -4px;
+        }
+
+        .zaius-promobar .md\:justify-center .timer-container{
+            margin-top: 14px;
         }
     }
     @media (min-width: 1536px) {

--- a/resources/views/promobar/component.blade.php
+++ b/resources/views/promobar/component.blade.php
@@ -46,8 +46,9 @@
     }
 
     .zaius-promobar .countdown-block{
-        background:  {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};;
-        color: {{ $payload['text_color'] ?? '#FFF'  }};
+        background: {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};
+        color: {{ $payload['text_color'] ?? '#000' }};
+        margin: 0px {{ $payload['countdown_timer_block_padding'] ?? 2 }}px }};
     }
 
     .zaius-promobar .block-info{
@@ -56,6 +57,7 @@
 
     .zaius-promobar .timer-container{
         padding: 2px 0px;
+        text-align: center;
     }
 
     .zaius-promobar .promobar-cta{

--- a/resources/views/promobar/component.blade.php
+++ b/resources/views/promobar/component.blade.php
@@ -9,7 +9,7 @@
         white-space: nowrap;
     }
 
-    .astrogoat_promobar_countdown {
+    .zaius_promobar_countdown {
         margin-left: 10px;
     }
 
@@ -39,25 +39,49 @@
         margin-left: 1rem;
     }
 
-    .astrogoat_promobar_countdown {
+    .zaius_promobar_countdown {
         margin-left: 10px;
         display: flex;
         justify-content: start;
     }
 
-    .zaius-promobar .countdown-block{
+    .zaius-promobar .countdown-block {
+        padding: 0 0.5rem;
+        border-radius: 0.125rem;
+        width: 1.56rem;
         background: {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};
         color: {{ $payload['text_color'] ?? '#000' }};
         margin: 0px {{ $payload['countdown_timer_block_padding'] ?? 2 }}px }};
     }
 
-    .zaius-promobar .block-info{
+    .zaius-promobar .block-info {
         text-align: center;
+        font-weight: bold;
+    }
+
+    .zaius-promobar .text-xs {
+        font-size: 0.75rem;
+        line-height: 1rem;
+    }
+
+    .zaius-promobar .font-bold{
+        font-weight: bold;
     }
 
     .zaius-promobar .timer-container{
         padding: 2px 0px;
         text-align: center;
+        display: flex;
+        gap: 0.5rem;
+    }
+
+    .zaius-promobar .seconds-block,
+    .zaius-promobar .minutes-block,
+    .zaius-promobar .months-block,
+    .zaius-promobar .days-block{
+        font-weight: bold;
+        display: flex;
+        gap: 0.25rem;
     }
 
     .zaius-promobar .promobar-cta{
@@ -118,7 +142,7 @@
         <div class="hidden md:flex">{!! $payload['content_desktop'] ?? '' !!}</div>
 
         @if($payload['countdown_timer_enabled'] ?? false)
-            <x-promobar::countdown :payload="$payload" class="astrogoat_promobar_countdown" />
+            <x-promobar::countdown :payload="$payload" class="zaius_promobar_countdown" />
         @endif
 
         @if($payload['zaius_content_id'] ?? null)

--- a/resources/views/promobar/component.blade.php
+++ b/resources/views/promobar/component.blade.php
@@ -39,6 +39,23 @@
         margin-left: 1rem;
     }
 
+    .astrogoat_promobar_countdown {
+        margin-left: 10px;
+    }
+
+    .zaius-promobar .countdown-block{
+        background:  {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};;
+        color: {{ $payload['text_color'] ?? '#FFF'  }};
+    }
+
+    .zaius-promobar .block-info{
+        text-align: center;
+    }
+
+    .zaius-promobar .timer-container{
+        padding: 2px 0px;
+    }
+
     @media (min-width: 768px) {
         .zaius-promobar .md\:hidden {
             display: none;

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -17,6 +17,8 @@
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
 
+
+                console.log(this.timerType);
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -12,22 +12,45 @@
         endsAtTime: '{{ $endsAtTime }}',
         startCounter: function () {
 
-        if( this.timerType === '24'){
-              let runningCounter = setInterval(() => {
+            if(this.timerType === '24'){
+                let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
-                let [hours, minutes, seconds] = this.endsAtTime.split(':');
-                let now = new Date();
-                let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
-                let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
                 let timeDistance = countDownDate - new Date().getTime();
+
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;
                 }
+
+                const [hours, minutes, seconds] = this.endsAtTime.split(':');
+                const now = new Date();
+                const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+
+                if(now > endTime){
+                    endTime.setDate(endTime.getDate() + 1);
+                }
+
+                const currentTime = new Date();
+                let tomorrowEndTimeDistance = endTime.getTime() - currentTime.getTime();
+
+                if(tomorrowEndTimeDistance <= 0){
+                    runningCounter = setInterval(resetCounter,1000);
+                }
+
                 this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
                 this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
                 this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
+
+                function resetCounter() {
+                    const now = new Date();
+                    const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+                    let tomorrowEndTimeDistance = endTime.getTime() - now.getTime();
+                    if (tomorrowEndTimeDistance <= 0) {
+                      clearInterval(runningCounter);
+                      runningCounter = setInterval(resetCounter, 1000);
+                    }
+                }
             }, 1000);
         }else{
             let runningCounter = setInterval(() => {

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -86,7 +86,6 @@
                 <span x-text="timer.minutes">{{ $minutes() }}</span> :
                 <span x-text="timer.seconds">{{ $seconds() }}</span>
             @else
-            here
                 {{ $slot }}
             @endif
         </span>

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -92,7 +92,7 @@
         <div class="flex gap-2 jmt-2 md:mt-0 timer-container" x-show="timerIsRunning">
             @if ($slot->isEmpty())
             <div class="flex flex-col" x-show="timerType === 'regular'">
-                <div class="flex days-block gap-1 font-bold mt-4">
+                <div class="flex days-block gap-1 font-bold">
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockTwo">-</span>
                 </div>
@@ -108,7 +108,7 @@
             </div>
 
             <div class="flex flex-col">
-                    <div class="flex minutes-block gap-1  font-bold">
+                    <div class="flex minutes-block gap-1 font-bold">
                         <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
                         <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
                     </div>
@@ -116,7 +116,7 @@
             </div>
 
             <div class="flex flex-col">
-                <div class="flex seconds-block gap-1 rounded-sm font-bold">
+                <div class="flex seconds-block gap-1 font-bold">
                     <span class="countdown-block px-2 rounded-sm" id="secondsBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="secondsBlockTwo">-</span>
                 </div>

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -17,8 +17,6 @@
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
 
-
-                console.log(this.timerType);
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -78,7 +78,6 @@
                         this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
                     }, 1000);
 
-
                     daysBlockOne.textContent = String(Math.floor(this.timer.days / 10));
                     daysBlockTwo.textContent = String(this.timer.days % 10);
                     hoursBlockOne.textContent = String(Math.floor(this.timer.hours / 10));
@@ -118,11 +117,11 @@
             </div>
 
             <div class="flex flex-col">
-                    <div class="flex minutes-block gap-1 font-bold">
-                        <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
-                        <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
-                    </div>
-                    <span class="text-xs font-bold text-center block-info">Mins</span>
+                <div class="flex minutes-block gap-1 font-bold">
+                    <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
+                </div>
+                <span class="text-xs font-bold text-center block-info">Mins</span>
             </div>
 
             <div class="flex flex-col">

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -100,14 +100,14 @@
         x-init="startCounter()"
         {{ $attributes }}
     >
-        <div class="flex gap-2 justify-center mt-4 md:mt-0 timer-container" x-show="timerIsRunning">
+        <div class="flex gap-2 jmt-2 md:mt-0 timer-container" x-show="timerIsRunning">
             @if ($slot->isEmpty())
             <div class="flex flex-col" x-show="timerType === 'regular'">
-                <div class="flex days-block gap-1 font-bold">
+                <div class="flex days-block gap-1 font-bold mt-4">
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockTwo">-</span>
                 </div>
-                <span class="text-xs  font-bold block-info">Days</span>
+                <span class="text-xs font-bold text-center block-info">Days</span>
             </div>
 
             <div class="flex flex-col">
@@ -115,7 +115,7 @@
                     <span class="countdown-block px-2 rounded-sm" id="hoursBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="hoursBlockTwo">-</span>
                 </div>
-                <span class="text-xs font-bold block-info">Hours</span>
+                <span class="text-xs font-bold text-center block-info">Hours</span>
             </div>
 
             <div class="flex flex-col">
@@ -123,7 +123,7 @@
                         <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
                         <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
                     </div>
-                    <span class="text-xs font-bold block-info">Mins</span>
+                    <span class="text-xs font-bold text-center block-info">Mins</span>
             </div>
 
             <div class="flex flex-col">
@@ -131,7 +131,7 @@
                     <span class="countdown-block px-2 rounded-sm" id="secondsBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="secondsBlockTwo">-</span>
                 </div>
-                <span class="text-xs font-bold block-info">Secs</span>
+                <span class="text-xs font-bold text-center block-info">Secs</span>
             </div>
             @else
                 {{ $slot }}

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -77,6 +77,16 @@
                         this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                         this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
                     }, 1000);
+
+
+                    daysBlockOne.textContent = String(Math.floor(this.timer.days / 10));
+                    daysBlockTwo.textContent = String(this.timer.days % 10);
+                    hoursBlockOne.textContent = String(Math.floor(this.timer.hours / 10));
+                    hoursBlockTwo.textContent = String(this.timer.hours % 10);
+                    minutesBlockOne.textContent = String(Math.floor(this.timer.minutes / 10));
+                    minutesBlockTwo.textContent = String(this.timer.minutes % 10);
+                    secondsBlockOne.textContent = String(Math.floor(this.timer.seconds / 10));
+                    secondsBlockTwo.textContent = String(this.timer.seconds % 10);
                 }
             },
             formatCounter: function (number) {

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -8,7 +8,28 @@
             minutes: '{{ $minutes() }}',
             seconds: '{{ $seconds() }}',
         },
+        timerType: '{{ $timerType }}',
+        endsAtTime: '{{ $endsAtTime }}',
         startCounter: function () {
+
+        if( this.timerType === '24'){
+              let runningCounter = setInterval(() => {
+                let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
+                let [hours, minutes, seconds] = this.endsAtTime.split(':');
+                let now = new Date();
+                let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
+                let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
+                let timeDistance = countDownDate - new Date().getTime();
+                if (timeDistance < 0 ) {
+                    clearInterval(runningCounter);
+                    return;
+                }
+                this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
+                this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
+                this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
+                this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
+            }, 1000);
+        }else{
             let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
@@ -21,6 +42,8 @@
                 this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
             }, 1000);
+        }
+
         },
         formatCounter: function (number) {
             return number.toString().padStart(2, '0');
@@ -40,6 +63,7 @@
                 <span x-text="timer.minutes">{{ $minutes() }}</span> :
                 <span x-text="timer.seconds">{{ $seconds() }}</span>
             @else
+            here
                 {{ $slot }}
             @endif
         </span>

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -1,5 +1,5 @@
 @if($timerIsRunning())
-    <span
+    <div
         x-data="
     {
         timer: {
@@ -42,6 +42,17 @@
                 this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
 
+
+                daysBlockOne.textContent = String(Math.floor(this.timer.days / 10));
+                daysBlockTwo.textContent = String(this.timer.days % 10);
+                hoursBlockOne.textContent = String(Math.floor(this.timer.hours / 10));
+                hoursBlockTwo.textContent = String(this.timer.hours % 10);
+                minutesBlockOne.textContent = String(Math.floor(this.timer.minutes / 10));
+                minutesBlockTwo.textContent = String(this.timer.minutes % 10);
+                secondsBlockOne.textContent = String(Math.floor(this.timer.seconds / 10));
+                secondsBlockTwo.textContent = String(this.timer.seconds % 10);
+
+
                 function resetCounter() {
                     const now = new Date();
                     const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
@@ -64,6 +75,16 @@
                 this.timer.hours = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
                 this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
+
+                daysBlockOne.textContent = String(Math.floor(this.timer.days / 10));
+                daysBlockTwo.textContent = String(this.timer.days % 10);
+                hoursBlockOne.textContent = String(Math.floor(this.timer.hours / 10));
+                hoursBlockTwo.textContent = String(this.timer.hours % 10);
+                minutesBlockOne.textContent = String(Math.floor(this.timer.minutes / 10));
+                minutesBlockTwo.textContent = String(this.timer.minutes % 10);
+                secondsBlockOne.textContent = String(Math.floor(this.timer.seconds / 10));
+                secondsBlockTwo.textContent = String(this.timer.seconds % 10);
+
             }, 1000);
         }
 
@@ -79,15 +100,42 @@
         x-init="startCounter()"
         {{ $attributes }}
     >
-        <span x-show="timerIsRunning">
+        <div class="flex gap-2 justify-center mt-4 md:mt-0 timer-container" x-show="timerIsRunning">
             @if ($slot->isEmpty())
-                <span x-text="timer.days">{{ $days() }}</span> :
-                <span x-text="timer.hours">{{ $hours() }}</span> :
-                <span x-text="timer.minutes">{{ $minutes() }}</span> :
-                <span x-text="timer.seconds">{{ $seconds() }}</span>
+            <div class="flex flex-col" x-show="timerType === 'regular'">
+                <div class="flex days-block gap-1 font-bold">
+                    <span class="countdown-block px-2 rounded-sm" id="daysBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded-sm" id="daysBlockTwo">-</span>
+                </div>
+                <span class="text-xs  font-bold block-info">Days</span>
+            </div>
+
+            <div class="flex flex-col">
+                <div class="flex months-block gap-1 font-bold">
+                    <span class="countdown-block px-2 rounded-sm" id="hoursBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded-sm" id="hoursBlockTwo">-</span>
+                </div>
+                <span class="text-xs font-bold block-info">Hours</span>
+            </div>
+
+            <div class="flex flex-col">
+                    <div class="flex minutes-block gap-1  font-bold">
+                        <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
+                        <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
+                    </div>
+                    <span class="text-xs font-bold block-info">Mins</span>
+            </div>
+
+            <div class="flex flex-col">
+                <div class="flex seconds-block gap-1 rounded-sm font-bold">
+                    <span class="countdown-block px-2 rounded-sm" id="secondsBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded-sm" id="secondsBlockTwo">-</span>
+                </div>
+                <span class="text-xs font-bold block-info">Secs</span>
+            </div>
             @else
                 {{ $slot }}
             @endif
-        </span>
-    </span>
+        </div>
+    </div>
 @endif

--- a/resources/views/promobar/components/countdown.blade.php
+++ b/resources/views/promobar/components/countdown.blade.php
@@ -98,38 +98,38 @@
         x-init="startCounter()"
         {{ $attributes }}
     >
-        <div class="flex gap-2 jmt-2 md:mt-0 timer-container" x-show="timerIsRunning">
+        <div class="flex timer-container" x-show="timerIsRunning">
             @if ($slot->isEmpty())
             <div class="flex flex-col" x-show="timerType === 'regular'">
-                <div class="flex days-block gap-1 font-bold">
-                    <span class="countdown-block px-2 rounded-sm" id="daysBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded-sm" id="daysBlockTwo">-</span>
+                <div class="flex days-block">
+                    <span class="countdown-block" id="daysBlockOne">-</span>
+                    <span class="countdown-block" id="daysBlockTwo">-</span>
                 </div>
-                <span class="text-xs font-bold text-center block-info">Days</span>
+                <span class="text-xs font-bold block-info">Days</span>
             </div>
 
             <div class="flex flex-col">
-                <div class="flex months-block gap-1 font-bold">
-                    <span class="countdown-block px-2 rounded-sm" id="hoursBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded-sm" id="hoursBlockTwo">-</span>
+                <div class="flex months-block">
+                    <span class="countdown-block" id="hoursBlockOne">-</span>
+                    <span class="countdown-block" id="hoursBlockTwo">-</span>
                 </div>
-                <span class="text-xs font-bold text-center block-info">Hours</span>
+                <span class="text-xs font-bold block-info">Hours</span>
             </div>
 
             <div class="flex flex-col">
-                <div class="flex minutes-block gap-1 font-bold">
-                    <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
+                <div class="flex minutes-block">
+                    <span class="countdown-block" id="minutesBlockOne">-</span>
+                    <span class="countdown-block" id="minutesBlockTwo">-</span>
                 </div>
-                <span class="text-xs font-bold text-center block-info">Mins</span>
+                <span class="text-xs font-bold block-info">Mins</span>
             </div>
 
             <div class="flex flex-col">
-                <div class="flex seconds-block gap-1 font-bold">
-                    <span class="countdown-block px-2 rounded-sm" id="secondsBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded-sm" id="secondsBlockTwo">-</span>
+                <div class="flex seconds-block">
+                    <span class="countdown-block" id="secondsBlockOne">-</span>
+                    <span class="countdown-block" id="secondsBlockTwo">-</span>
                 </div>
-                <span class="text-xs font-bold text-center block-info">Secs</span>
+                <span class="text-xs font-bold block-info">Secs</span>
             </div>
             @else
                 {{ $slot }}

--- a/resources/views/promobar/settings.blade.php
+++ b/resources/views/promobar/settings.blade.php
@@ -100,10 +100,12 @@
         :toggled="$payload['countdown_timer_enabled'] ?? false"
     />
 
-
-     <x-fab::forms.select
+    <div
         x-cloak
         x-show="payload.countdown_timer_enabled === true"
+    >
+     <x-fab::forms.select
+
         wire:model="payload.countdown_timer_type"
         wire:key="promobar_countdown_timer_type"
         name="payload[countdown_timer_type]"
@@ -112,6 +114,7 @@
         <option value="24">24 Hours Countdown</option>
         <option value="regular">Regular Countdown</option>
     </x-fab::forms.select>
+    </div>
 
     <div
         class="grid grid-cols-2 w-full fab-space-x-4"

--- a/resources/views/promobar/settings.blade.php
+++ b/resources/views/promobar/settings.blade.php
@@ -107,7 +107,7 @@
     >
 
 
-     <x-fab::forms.select
+    <x-fab::forms.select
         wire:model="payload.countdown_timer_type"
         wire:key="promobar_countdown_timer_type"
         name="payload[countdown_timer_type]"

--- a/resources/views/promobar/settings.blade.php
+++ b/resources/views/promobar/settings.blade.php
@@ -101,11 +101,13 @@
     />
 
     <div
+        class="grid grid-cols-2 w-full fab-space-x-4"
         x-cloak
-
-    >
-     <x-fab::forms.select
         x-show="payload.countdown_timer_enabled === true"
+    >
+
+
+     <x-fab::forms.select
         wire:model="payload.countdown_timer_type"
         wire:key="promobar_countdown_timer_type"
         name="payload[countdown_timer_type]"
@@ -114,6 +116,16 @@
         <option value="regular">Regular Countdown</option>
         <option value="24">24 Hours Countdown</option>
     </x-fab::forms.select>
+
+
+    <x-fab::forms.input
+            label="Block Background Color"
+            type="color"
+            wire:model="payload.countdown_timer_block_background_color"
+            wire:key="promobar_countdown_timer_block_background_color"
+    />
+
+
     </div>
 
     <div

--- a/resources/views/promobar/settings.blade.php
+++ b/resources/views/promobar/settings.blade.php
@@ -102,17 +102,17 @@
 
     <div
         x-cloak
-        x-show="payload.countdown_timer_enabled === true"
+
     >
      <x-fab::forms.select
-
+        x-show="payload.countdown_timer_enabled === true"
         wire:model="payload.countdown_timer_type"
         wire:key="promobar_countdown_timer_type"
         name="payload[countdown_timer_type]"
         label="Countdown Timer Type"
     >
-        <option value="24">24 Hours Countdown</option>
         <option value="regular">Regular Countdown</option>
+        <option value="24">24 Hours Countdown</option>
     </x-fab::forms.select>
     </div>
 

--- a/resources/views/promobar/settings.blade.php
+++ b/resources/views/promobar/settings.blade.php
@@ -100,6 +100,19 @@
         :toggled="$payload['countdown_timer_enabled'] ?? false"
     />
 
+
+     <x-fab::forms.select
+        x-cloak
+        x-show="payload.countdown_timer_enabled === true"
+        wire:model="payload.countdown_timer_type"
+        wire:key="promobar_countdown_timer_type"
+        name="payload[countdown_timer_type]"
+        label="Countdown Timer Type"
+    >
+        <option value="24">24 Hours Countdown</option>
+        <option value="regular">Regular Countdown</option>
+    </x-fab::forms.select>
+
     <div
         class="grid grid-cols-2 w-full fab-space-x-4"
         x-cloak

--- a/resources/views/promobar/settings.blade.php
+++ b/resources/views/promobar/settings.blade.php
@@ -101,22 +101,6 @@
     />
 
     <div
-        x-cloak
-
-    >
-     <x-fab::forms.select
-        x-show="payload.countdown_timer_enabled === true"
-        wire:model="payload.countdown_timer_type"
-        wire:key="promobar_countdown_timer_type"
-        name="payload[countdown_timer_type]"
-        label="Countdown Timer Type"
-    >
-        <option value="regular">Regular Countdown</option>
-        <option value="24">24 Hours Countdown</option>
-    </x-fab::forms.select>
-    </div>
-
-    <div
         class="grid grid-cols-2 w-full fab-space-x-4"
         x-cloak
         x-show="payload.countdown_timer_enabled === true"
@@ -132,15 +116,6 @@
         <option value="regular">Regular Countdown</option>
         <option value="24">24 Hours Countdown</option>
     </x-fab::forms.select>
-
-
-    <x-fab::forms.input
-            label="Block Background Color"
-            type="color"
-            wire:model="payload.countdown_timer_block_background_color"
-            wire:key="promobar_countdown_timer_block_background_color"
-    />
-
 
     </div>
 
@@ -175,6 +150,30 @@
     </div>
 </div>
 
+
+ <div
+    class="grid grid-cols-2 w-full gap-4 mt-4 p-2"
+    x-cloak
+    x-show="payload.countdown_timer_enabled === true"
+ >
+        <x-fab::forms.input
+            label="Block Background Color"
+            type="color"
+            wire:model="payload.countdown_timer_block_background_color"
+            wire:key="promobar_countdown_timer_block_background_color"
+        />
+
+        <x-fab::forms.range
+            label="Block L & R Padding"
+            min="0"
+            max="2"
+            name="payload['countdown_timer_block_padding']"
+            wire:model="payload.countdown_timer_block_padding"
+            wire:key="promobar_countdown_timer_block_padding"
+            placeholder="2"
+            trailing="px"
+        />
+</div>
 <x-fab::forms.input
     class="mt-6"
     label="Zaius content ID"

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public string $timerType;
-    public string $endsAtTime;
+    public ?string $timerType;
+    public ?string $endsAtTime;
 
     public function __construct(protected array $payload)
     {

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -15,7 +15,6 @@ class Countdown extends Component
     public ?Carbon $startsAt;
     public ?string $timerType;
     public ?string $endsAtTime;
-    public $bb;
 
     public function __construct(protected array $payload)
     {

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -13,6 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
+    public $timerType;
+    public $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -21,6 +23,10 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
+
+        $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
+
+        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
     }
 
     public function days(): string

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public $timerType;
-    public $endsAtTime;
+    public string $timerType;
+    public string $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -23,10 +23,8 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
-
-        $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
-
-        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
+        $this->timerType = $this->payload['countdown_timer_type'] ?? "";
+        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : "";
     }
 
     public function days(): string

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -63,6 +63,6 @@ class Countdown extends Component
 
     public function render()
     {
-        return view('promobar::components.countdown');
+        return view('zaius::components.countdown');
     }
 }

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -15,6 +15,7 @@ class Countdown extends Component
     public ?Carbon $startsAt;
     public ?string $timerType;
     public ?string $endsAtTime;
+    public  $bb;
 
     public function __construct(protected array $payload)
     {

--- a/src/Promobar/Components/Countdown.php
+++ b/src/Promobar/Components/Countdown.php
@@ -15,7 +15,7 @@ class Countdown extends Component
     public ?Carbon $startsAt;
     public ?string $timerType;
     public ?string $endsAtTime;
-    public  $bb;
+    public $bb;
 
     public function __construct(protected array $payload)
     {


### PR DESCRIPTION
**Link to ticket**: https://linear.app/3zbrands/issue/BYTE-158/styling

<details>
<summary>Ticket description</summary>
As a user looking at the promobar when the countdown timer is enabled, I want to see the countdown timer sitting between the copy and the View Offer link (if it exists) so that I know how much time remains until the sale ends.
</details>

