### PR TITLE
NEW-2534: Navigation - Promotional Bar - Fix Center-Alignment on Mobile

### DIFF
--- a/resources/views/promobar/component.blade.php
+++ b/resources/views/promobar/component.blade.php
@@ -104,10 +104,18 @@
         .zaius-promobar .container {
             max-width: 640px;
         }
+
+        .zaius-promobar .promobar-cta{
+            margin-left: 0px;
+        }
     }
     @media (min-width: 768px) {
         .zaius-promobar .container {
             max-width: 768px;
+        }
+
+        .zaius-promobar .promobar-cta{
+            margin-left: 1rem;
         }
     }
     @media (min-width: 1024px) {
@@ -146,7 +154,7 @@
         @endif
 
         @if($payload['zaius_content_id'] ?? null)
-            <button type="button" class="ml-4 no-wrap promobar-cta" onclick="openZaiusModal('{{ $payload['zaius_content_id'] ?? '' }}')">{!! $payload['button'] ?? '' !!}</button>
+            <button type="button" class="no-wrap promobar-cta" onclick="openZaiusModal('{{ $payload['zaius_content_id'] ?? '' }}')">{!! $payload['button'] ?? '' !!}</button>
         @endif
     </div>
 </div>


### PR DESCRIPTION
**Link to ticket**: https://linear.app/3zbrands/issue/NEW-2534/helix-navigation-promotional-bar-fix-center-alignment-on-mobile

<details>
<summary>Ticket description</summary>
The promotion text has been off-center for awhile now. Would love make sure it's aligned on mobile. Highlighted content below so you can see the misalignment. Same problem exists on Birch as well.
</details>

